### PR TITLE
Don't remove singletons during shutdown

### DIFF
--- a/src/winhttppal.cpp
+++ b/src/winhttppal.cpp
@@ -575,8 +575,8 @@ void ComContainer::FreeCURL(CURL *ptr)
 
 ComContainer &ComContainer::GetInstance()
 {
-    static ComContainer the_instance;
-    return the_instance;
+    static ComContainer *the_instance = new ComContainer();
+    return *the_instance;
 }
 
 void ComContainer::ResumeTransfer(CURL *handle, int bitmask)

--- a/src/winhttppal_imp.h
+++ b/src/winhttppal_imp.h
@@ -497,8 +497,8 @@ class WinHttpHandleContainer
 public:
     static WinHttpHandleContainer &Instance()
     {
-        static WinHttpHandleContainer the_instance;
-        return the_instance;
+        static WinHttpHandleContainer *the_instance = new WinHttpHandleContainer<T>();
+        return *the_instance;
     }
 
     void UnRegister(T *val);


### PR DESCRIPTION
Signed-off-by: Sinan Kaya <sinan.kaya@microsoft.com>