### PR TITLE
Fix Continue response handling

### DIFF
--- a/src/winhttppal.cpp
+++ b/src/winhttppal.cpp
@@ -1080,7 +1080,7 @@ size_t WinHttpRequestImp::WriteHeaderFunction(void *ptr, size_t size, size_t nme
         DWORD retValue = 501;
 
         TRACE_VERBOSE("%-35s:%-8d:%-16p Header string:%s\n", __func__, __LINE__, (void*)request, request->GetHeaderString().c_str());
-        regstr.append("^HTTP.*[0-9]{3}");
+        regstr.append("^HTTP/[0-9.]* [0-9]{3}");
         std::vector<std::string> result = FindRegexA(request->GetHeaderString(), regstr);
         for (auto codestr : result)
         {
@@ -1106,6 +1106,8 @@ size_t WinHttpRequestImp::WriteHeaderFunction(void *ptr, size_t size, size_t nme
         }
         else
         {
+            std::lock_guard<std::mutex> lck(request->GetHeaderStringMutex());
+            request->GetHeaderString() = "";
             TRACE("%-35s:%-8d:%-16p retValue = %lu \n", __func__, __LINE__, (void*)request, retValue);
         }
 


### PR DESCRIPTION
If server returned "HTTP/1.1 100 Continue", then headers string
was not cleared.
So when, after that, another response "HTTP/1.1 200 OK" came,
we were processing headers when other thread was adding them.
And we got into race condition state when sometimes we were
able to get all headers, and sometimes we were not.

Server response example:
```
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Cache-Control: no-cache
Content-Length: 5434
Content-Type: application/json; charset=utf-8
Date: Tue, 23 Nov 2021 11:56:45 GMT
```

Also potential problem with HTTP status string parsing was fixed.
We were using regex "^HTTP.*[0-9]{3}" for the string that includes
headers. So basically any 3 numbers in headers could be considered
as HTTP response
For example here we returned 434
```
HTTP/1.1 200 OK
Cache-Control: no-cache
Content-Length: 5434
```